### PR TITLE
Stability Fix and Documentation Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ bin/
 getting-started/configs
 
 k8s/__dev-*/**
+materials/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV JAVA_OPTS=""
 
 # Command to run your application
 #ENTRYPOINT ["java", "-jar", "app.jar"]
-ENTRYPOINT java $JAVA_OPTS -jar app.jar proxy.properties
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar proxy.properties"]
 
 # Let's run as non-root user: kproxy
 RUN groupadd --system kproxy && useradd --system --gid kproxy kproxy

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ ls demo-consumer/target/kafka-demo-consumer-*.jar
 # Run demo producer (from separate JAR)
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config getting-started/sample-configs/demo-producer.properties \
-     --topic PRODUCE_TO:test-topic \
+     --topic PRODUCER_TOPIC:test-topic \
      --num-records 10
 
 # Run demo consumer (from separate JAR)

--- a/getting-started/SampleKafkaClient.md
+++ b/getting-started/SampleKafkaClient.md
@@ -15,7 +15,14 @@ The demo clients are in separate sub-projects with their own directories. Build 
 
 ```bash
 # From the project root directory
+# Build Proxy
 mvn clean package
+
+# Sample Kafka producer
+mvn clean package -f demo-producer/pom.xml
+
+# Sample Kafka consumer
+mvn clean package -f demo-consumer/pom.xml
 
 # This creates separate JAR files:
 # - Main proxy JAR
@@ -27,6 +34,7 @@ ls demo-consumer/target/kafka-demo-consumer-*.jar
 ```
 
 > **Note**: The version number in the JAR file of ***Kafka Demo Clients*** name reflects the version of the Kafka client library that was used to compile it. For example, `kafka-demo-producer-3.9.1.jar` indicates it was compiled with Kafka client version 3.9.1.
+>> You can change the version of `kafka-clients` module in the `pom.xml` file to create different versions of the clients for testing.
 
 ## Configuration Files
 
@@ -78,12 +86,15 @@ java -jar target/kafka-wireline-proxy-*.jar \
 ```
 
 The proxy should display:
+```log
+15:50:28.636 [main] INFO  HealthCheckServer - Health check server started on port 8080
+15:50:28.638 [main] INFO  ProxyMain - Health check server started on port 8080
+15:50:28.652 [main] INFO  ProxyReactor - Listening for incoming connections on PLAINTEXT localhost/127.0.0.1:9092
+15:50:28.653 [main] INFO  ProxyReactor - Listening for incoming connections on SASL_SSL localhost/127.0.0.1:9094
+15:50:28.791 [main] INFO  ProxyReactor - Initializing request handler thread pool with 32 threads.
 ```
-INFO: Kafka Proxy started successfully
-INFO: Listening on PLAINTEXT://localhost:9092
-INFO: Listening on SASL_SSL://localhost:9094
-INFO: Health check server started on port 8080
-```
+
+> **Note:** HealthCheckServer logs will be included if property `proxy.healthcheckserver.create=true`.
 
 ### Start Demo Consumer
 
@@ -119,23 +130,29 @@ Open another terminal and start the demo producer:
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
      --topic PRODUCE_TO:test-topic \
-     --num-records 10
+     --input-file getting-started/test-data/publish-data-kv-10-fixed.txt \
+     --num-records 10 \
+     --delay 5
 ```
 
 **Command Arguments:**
 - `--config demo-producer.properties` - Producer configuration file
 - `--topic PRODUCE_TO:test-topic` - Kafka topic to publish to (note the PRODUCE_TO prefix)
+- `--input-file getting-started/test-data/publish-data-kv-10-fixed.txt` - Test Data File containing records with 10 unique Keys
 - `--num-records 10` - Number of messages to send
+- `--delay 5` - Delay in milliseconds between requests to publish messages (can be 0)
 
 **Expected Output:**
-```
-Demo Producer starting...
-Sending 10 messages to topic: test-topic
-Message 1 sent: Hello from Demo Producer - Message 1
-Message 2 sent: Hello from Demo Producer - Message 2
+```log
 ...
-Message 10 sent: Hello from Demo Producer - Message 10
-Producer completed successfully
+INFO  - Starting to send messages to topic 'PRODUCER_TOPIC:ORDER_CHANGES'. Press Ctrl+C to exit.
+...
+INFO  - SENT 0000000000 : The old house on the hill seemed to whisper secrets to the passing travelers
+INFO  - SENT 1111111111 : A gentle breeze rustled through the tall grass creating a soothing melody
+INFO  - SENT 2222222222 : Ancient forest stood as a silent guardian watching over the sleeping valley
+...
+INFO  - SENT 8888888888 : Train rumbled along the tracks carrying passengers to their unknown destinations
+INFO  - SENT 9999999999 : The chef prepared a delicious meal the aroma filling the entire restaurant
 ```
 
 ### Verify Message Delivery
@@ -148,6 +165,8 @@ Received message: Hello from Demo Producer - Message 2
 ...
 Received message: Hello from Demo Producer - Message 10
 ```
+
+> **Note:** `Control-C` to close out of the consumer; Producer will terminate when the number of messages specified has been sent.
 
 ## SSL/TLS Testing
 
@@ -305,11 +324,11 @@ java -jar demo-producer/target/kafka-demo-producer-*.jar \
 ```
 
 **Parameters:**
-- `--config <config-file>` - Producer properties file
-- `--topic PRODUCE_TO:<topic-name>` - Target Kafka topic (PRODUCE_TO prefix required)
-- `--num-records <message-count>` - Number of messages to send
-- `--input-file <input-file>` - Optional: Custom input file for message content
-- `-d <delay-millis>` - Optional: Delay between messages in milliseconds
+- `-c | --config      <config-file>` - Producer properties file
+- `-t | --topic       PRODUCE_TO:<topic-name>` - Target Kafka topic (PRODUCE_TO prefix required)
+- `-n | --num-records <message-count>` - Number of messages to send
+- `-i | --input-file  <input-file>` - Optional: Custom input file for message content
+- `-d | --delay       <delay-millis>` - Optional: Delay between messages in milliseconds
 
 ### DemoConsumer Usage
 

--- a/getting-started/SampleKafkaClient.md
+++ b/getting-started/SampleKafkaClient.md
@@ -129,7 +129,7 @@ Open another terminal and start the demo producer:
 # Run the demo producer from its own JAR
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:test-topic \
+     --topic PRODUCER_TOPIC:test-topic \
      --input-file getting-started/test-data/publish-data-kv-10-fixed.txt \
      --num-records 10 \
      --delay 5
@@ -137,7 +137,7 @@ java -jar demo-producer/target/kafka-demo-producer-*.jar \
 
 **Command Arguments:**
 - `--config demo-producer.properties` - Producer configuration file
-- `--topic PRODUCE_TO:test-topic` - Kafka topic to publish to (note the PRODUCE_TO prefix)
+- `--topic PRODUCER_TOPIC:test-topic` - Kafka topic to publish to (note the PRODUCER_TOPIC prefix)
 - `--input-file getting-started/test-data/publish-data-kv-10-fixed.txt` - Test Data File containing records with 10 unique Keys
 - `--num-records 10` - Number of messages to send
 - `--delay 5` - Delay in milliseconds between requests to publish messages (can be 0)
@@ -198,7 +198,7 @@ java -jar demo-consumer/target/kafka-demo-consumer-*.jar \
 # Producer with SSL
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:ssl-test-topic \
+     --topic PRODUCER_TOPIC:ssl-test-topic \
      --num-records 5
 ```
 
@@ -250,7 +250,7 @@ Test topic name conversion (if `proxy.separators` is configured):
 # This topic name will be converted: my_test.topic -> my/test/topic
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:my_test.topic \
+     --topic PRODUCER_TOPIC:my_test.topic \
      --num-records 5
 ```
 
@@ -262,7 +262,7 @@ Generate more messages for throughput testing:
 # Send 1000 messages
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:perf-test-topic \
+     --topic PRODUCER_TOPIC:perf-test-topic \
      --num-records 1000
 ```
 
@@ -274,7 +274,7 @@ Use custom test data from files:
 # Producer with custom input file
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:file-test-topic \
+     --topic PRODUCER_TOPIC:file-test-topic \
      --input-file /path/to/test-data/messages.txt \
      --num-records 50
 ```
@@ -287,7 +287,7 @@ Add delays between messages for controlled testing:
 # Producer with 100ms delay between messages
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:delayed-topic \
+     --topic PRODUCER_TOPIC:delayed-topic \
      --num-records 10 \
      -d 100
 ```
@@ -300,13 +300,13 @@ Run multiple producers simultaneously:
 # Terminal 1
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:batch-topic \
+     --topic PRODUCER_TOPIC:batch-topic \
      --num-records 50 &
 
 # Terminal 2
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:batch-topic \
+     --topic PRODUCER_TOPIC:batch-topic \
      --num-records 50 &
 ```
 
@@ -317,7 +317,7 @@ java -jar demo-producer/target/kafka-demo-producer-*.jar \
 ```bash
 java -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config <config-file> \
-     --topic PRODUCE_TO:<topic-name> \
+     --topic PRODUCER_TOPIC:<topic-name> \
      --num-records <message-count> \
      [--input-file <input-file>] \
      [-d <delay-millis>]
@@ -325,7 +325,7 @@ java -jar demo-producer/target/kafka-demo-producer-*.jar \
 
 **Parameters:**
 - `-c | --config      <config-file>` - Producer properties file
-- `-t | --topic       PRODUCE_TO:<topic-name>` - Target Kafka topic (PRODUCE_TO prefix required)
+- `-t | --topic       PRODUCER_TOPIC:<topic-name>` - Target Kafka topic (PRODUCER_TOPIC prefix required)
 - `-n | --num-records <message-count>` - Number of messages to send
 - `-i | --input-file  <input-file>` - Optional: Custom input file for message content
 - `-d | --delay       <delay-millis>` - Optional: Delay between messages in milliseconds
@@ -353,7 +353,7 @@ java -Dlog4j.configurationFile=log4j2.xml \
      -Dlog4j2.logger.com.solace.kafka.kafkaproxy.demo.level=DEBUG \
      -jar demo-producer/target/kafka-demo-producer-*.jar \
      --config demo-producer.properties \
-     --topic PRODUCE_TO:test-topic \
+     --topic PRODUCER_TOPIC:test-topic \
      --num-records 10
 ```
 

--- a/k8s/aws-eks-deploy/aws-eks-instructions.md
+++ b/k8s/aws-eks-deploy/aws-eks-instructions.md
@@ -126,7 +126,7 @@ echo "Testing plaintext connection..."
 nc -zv $BOOTSTRAP_LB 9092
 
 # Test with Kafka client (replace with your test topic)
-# kafka-console-producer.sh --bootstrap-server $BOOTSTRAP_LB:9094 --topic PRODUCE_TO:test-topic --producer.config ssl.properties
+# kafka-console-producer.sh --bootstrap-server $BOOTSTRAP_LB:9094 --topic PRODUCER_TOPIC:test-topic --producer.config ssl.properties
 ```
 
 ## Troubleshooting

--- a/k8s/aws-eks-deploy/proxy-sts.yaml
+++ b/k8s/aws-eks-deploy/proxy-sts.yaml
@@ -128,11 +128,11 @@ spec:
               readOnly: true
           resources:
             limits:
-              memory: "1280Mi"
+              memory: "1536Mi"
               cpu: "1"
             requests:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "1536Mi"
+              cpu: "1"
       volumes:
         - name: kafka-keystore-volume
           secret:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
  
   <groupId>com.solace.kafkawireline</groupId>
   <artifactId>kafka-wireline-proxy</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <packaging>jar</packaging>
 
   <name>Kafka Wireline Proxy</name>
@@ -13,6 +13,8 @@
     This project defines a deployable proxy that enables Kafka producers 
     and consumers to publish to Solace topics and subscribe to Solace queues.
   </description>
+
+  <url>https://github.com/SolaceLabs/kafka-client-proxy-to-solace</url>
 
   <developers>
     <developer>

--- a/src/main/java/com/solace/kafka/kafkaproxy/ProxyReactor.java
+++ b/src/main/java/com/solace/kafka/kafkaproxy/ProxyReactor.java
@@ -85,6 +85,11 @@ public class ProxyReactor extends Thread {
         private final Set<ProxyChannel> channels;  // channels accepted on this listen port
         private final MetadataResponseData.MetadataResponseBrokerCollection brokers = new MetadataResponseData.MetadataResponseBrokerCollection();
         private final SslFactory sslFactory;
+
+        public boolean isTlsPort() {
+            return listenEntry.getSecurityProtocol() == SecurityProtocol.SSL ||
+                   listenEntry.getSecurityProtocol() == SecurityProtocol.SASL_SSL;
+        }
         
         // taken from org.apache.kafka.common.network.ChannelBuilders.channelBuilderConfigs()
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Stability Fix
When unencrypted connections were being made to TLS port, the proxy would eventually become unstable and crash with out-of-memory errors. The connection was causing a loop allocating memory which was never being released.
- The proxy now checks if a connection on TLS protected port is requesting TLS handshake. If it is proceed, otherwise close the connection gracefully and close the channel and allocated resources.

## Documentation Enhancements
- The documentation incorrectly identified the producer topic identifier.
    - Corrected in Readme.md and SampleKafkaClient.md
- Added "usage" section to readme to describe how to establish Solace queues to use with the proxy