### PR TITLE
bugfix-empty property causing npe

### DIFF
--- a/demo-producer/pom.xml
+++ b/demo-producer/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>3.7.1</kafka.version>
+        <kafka.version>3.9.1</kafka.version>
         <slf4j.version>2.0.12</slf4j.version>
         <log4j2.version>2.23.0</log4j2.version>
         <commons-cli.version>1.7.0</commons-cli.version>

--- a/src/main/java/com/solace/kafka/kafkaproxy/ProxyConfig.java
+++ b/src/main/java/com/solace/kafka/kafkaproxy/ProxyConfig.java
@@ -290,7 +290,7 @@ public class ProxyConfig  extends AbstractConfig {
     
     public static String resolvePropertyValueFromEnv(final String propertyValue) throws ConfigException{
         if (propertyValue == null || propertyValue.isEmpty()) {
-            return null;
+            return "";
         }
 
         final Matcher matcher = PATTERN.matcher(propertyValue);


### PR DESCRIPTION
## Bugfix update
- bugfix: empty property value causing null pointer exception, will now resolve to empty string
- also set demo-producer/pom.xml kafka lib to 3.9.1
